### PR TITLE
Fix total axis label collisions

### DIFF
--- a/R/waterfall.R
+++ b/R/waterfall.R
@@ -174,16 +174,17 @@ waterfall <- function(.data = NULL,
       ggplot2::geom_blank() +
       ggplot2::theme(axis.title = ggplot2::element_blank())
   } else {
+    total_position <- number_of_rectangles + 1L
     p <-
       if (scale_y_to_waterfall) {
-        ggplot2::ggplot(data.frame(x = c(factor(1:length(labels)), total_axis_text,
-                                         factor(1:length(labels)), total_axis_text),
+        ggplot2::ggplot(data.frame(x = factor(c(1:length(labels), total_position,
+                                                1:length(labels), total_position)),
                                    y = c(south_edge, north_edge,
                                          south_edge[number_of_rectangles],
                                          north_edge[number_of_rectangles])),
                         ggplot2::aes(x = .data$x, y = .data$y))
       } else {
-        ggplot2::ggplot(data.frame(x = c(factor(1:length(labels)), total_axis_text),
+        ggplot2::ggplot(data.frame(x = factor(c(1:length(labels), total_position)),
                                    y = c(values, north_edge[number_of_rectangles])),
                         ggplot2::aes(x = .data$x, y = .data$y))
       }


### PR DESCRIPTION
Fixes the x-axis label handling when `total_axis_text` matches an internal x-axis value.

Previously, `total_axis_text` was used both as display text and as the total bar's internal x value. Values such as `"1"` therefore collided with an existing category, causing the total label to disappear.

This change:

- uses a dedicated internal position for the total bar
- uses `total_axis_text` only as the displayed label

Closes #14